### PR TITLE
feat(Secret): Add API for store/retrieve secret files

### DIFF
--- a/backend/src/BlogDoFt.SbusEmulatorViewer.Api/BlogDoFt.SbusEmulatorViewer.Api.csproj
+++ b/backend/src/BlogDoFt.SbusEmulatorViewer.Api/BlogDoFt.SbusEmulatorViewer.Api.csproj
@@ -1,18 +1,36 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>a21f5f75-eacf-4a74-bee5-2969ffc0da77</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.19.0" />
+    <PackageReference Include="Dapper" Version="2.1.66" />
+    <PackageReference Include="FluentMigrator" Version="7.1.0" />
+    <PackageReference Include="FluentMigrator.Runner.Postgres" Version="7.1.0" />
+    <PackageReference Include="FluentMigrator.Extensions.Postgres" Version="7.1.0" />
+    <PackageReference Include="Npgsql" Version="9.0.3" />    
     <PackageReference Include="System.Text.Json" Version="9.0.5" />    
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="8.1.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.ReDoc" Version="8.1.1" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.11.0.117924">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>  
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>    
+    <AdditionalFiles Include="..\..\stylecop.json" /> 
   </ItemGroup>
 
 </Project>

--- a/backend/src/BlogDoFt.SbusEmulatorViewer.Api/Database/Migrations/M202506141518CreateEncryptedFilesTable.cs
+++ b/backend/src/BlogDoFt.SbusEmulatorViewer.Api/Database/Migrations/M202506141518CreateEncryptedFilesTable.cs
@@ -1,0 +1,23 @@
+using FluentMigrator;
+
+namespace BlogDoFt.SbusEmulatorViewer.Api.Database.Migrations;
+
+[Migration(version: 202506141518, description: "Create Secrets table.")]
+public class M202506141518CreateEncryptedFilesTable : Migration
+{
+    public override void Up()
+    {
+        Create.Table("encrypted_files")
+            .WithColumn("id").AsInt32().PrimaryKey().Identity()
+            .WithColumn("navigation_id").AsGuid().NotNullable().Indexed("idx_sh_encrypted_files_navigationid")
+            .WithColumn("file_name").AsString().NotNullable().Unique("idx_uk_encrypted_files_file_name")
+            .WithColumn("content").AsCustom("BYTEA").NotNullable()
+            .WithColumn("iv").AsCustom("BYTEA").NotNullable()
+            .WithColumn("created_at").AsDateTime().WithDefault(SystemMethods.CurrentDateTime);
+    }
+
+    public override void Down()
+    {
+        Delete.Table("encrypted_files");
+    }
+}

--- a/backend/src/BlogDoFt.SbusEmulatorViewer.Api/Features/Secrets/ISecretCriptographyService.cs
+++ b/backend/src/BlogDoFt.SbusEmulatorViewer.Api/Features/Secrets/ISecretCriptographyService.cs
@@ -1,0 +1,10 @@
+using BlogDoFt.SbusEmulatorViewer.Api.Features.Secrets.Models;
+
+namespace BlogDoFt.SbusEmulatorViewer.Api.Features.Secrets;
+
+public interface ISecretCriptographyService
+{
+    (MemoryStream Text, byte[] IV) Encrypt(SecretSaveModel model);
+
+    Task<(string Filename, MemoryStream Content)> DecryptAsync(SecretsTable model);
+}

--- a/backend/src/BlogDoFt.SbusEmulatorViewer.Api/Features/Secrets/ISecretRepository.cs
+++ b/backend/src/BlogDoFt.SbusEmulatorViewer.Api/Features/Secrets/ISecretRepository.cs
@@ -1,0 +1,10 @@
+using BlogDoFt.SbusEmulatorViewer.Api.Features.Secrets.Models;
+
+namespace BlogDoFt.SbusEmulatorViewer.Api.Features.Secrets;
+
+public interface ISecretRepository
+{
+    Task<Guid> SaveAsync(MemoryStream text, byte[] iv, string fileName);
+
+    Task<SecretsTable?> QueryById(Guid navigationId);
+}

--- a/backend/src/BlogDoFt.SbusEmulatorViewer.Api/Features/Secrets/Impl/SecretCriptographyService.cs
+++ b/backend/src/BlogDoFt.SbusEmulatorViewer.Api/Features/Secrets/Impl/SecretCriptographyService.cs
@@ -1,0 +1,51 @@
+using BlogDoFt.SbusEmulatorViewer.Api.Features.Secrets.Models;
+using System.Security.Cryptography;
+
+namespace BlogDoFt.SbusEmulatorViewer.Api.Features.Secrets.Impl;
+
+internal class SecretCriptographyService : ISecretCriptographyService
+{
+    private readonly byte[] _cryptoKey = Convert.FromBase64String("rGh3sZXc4YHkc7Y6ZVqtqv7YXym+d1Ns1jEGPa+dglk=");
+
+    public async Task<(string Filename, MemoryStream Content)> DecryptAsync(SecretsTable model)
+    {
+        if (model.Content is null)
+        {
+            throw new ArgumentNullException(nameof(model));
+        }
+
+        await using var encryptedStream = new MemoryStream(model.Content);
+        var decryptedStream = new MemoryStream();
+
+        using (var aes = Aes.Create())
+        {
+            aes.Key = _cryptoKey;
+            aes.IV = model.IV;
+
+            await using var cryptoStream = new CryptoStream(encryptedStream, aes.CreateDecryptor(), CryptoStreamMode.Read);
+            await cryptoStream.CopyToAsync(decryptedStream);
+        }
+
+        return (model.FileName ?? "unspecified", decryptedStream);
+    }
+
+    public (MemoryStream Text, byte[] IV) Encrypt(SecretSaveModel model)
+    {
+        var iv = new byte[16];
+        MemoryStream memoryStream = new();
+        using (var aes = Aes.Create())
+        {
+            aes.Key = _cryptoKey;
+            aes.GenerateIV();
+            iv = aes.IV;
+
+            ICryptoTransform encryptor = aes.CreateEncryptor(aes.Key, aes.IV);
+
+            using CryptoStream cryptoStream = new(memoryStream, encryptor, CryptoStreamMode.Write);
+            using StreamWriter streamWriter = new(cryptoStream);
+            streamWriter.Write(model.Text);
+        }
+
+        return (memoryStream, iv);
+    }
+}

--- a/backend/src/BlogDoFt.SbusEmulatorViewer.Api/Features/Secrets/Impl/SecretRepository.cs
+++ b/backend/src/BlogDoFt.SbusEmulatorViewer.Api/Features/Secrets/Impl/SecretRepository.cs
@@ -1,0 +1,47 @@
+using BlogDoFt.SbusEmulatorViewer.Api.Features.Secrets.Models;
+using Dapper;
+using System.Data;
+
+namespace BlogDoFt.SbusEmulatorViewer.Api.Features.Secrets.Impl;
+
+internal class SecretRepository : ISecretRepository
+{
+    private readonly IDbConnection _db;
+
+    public SecretRepository(IDbConnection db)
+    {
+        _db = db;
+    }
+
+    public async Task<SecretsTable?> QueryById(Guid navigationId)
+    {
+        var sql =
+            """ 
+                SELECT id
+                     , navigation_id as NavigationId
+                     , file_name as FileName
+                     , "content"
+                     , iv
+                FROM public.encrypted_files
+                where navigation_id = @NavigationId;
+            """;
+        var result = await _db.QueryFirstOrDefaultAsync<SecretsTable>(sql, new { navigationId });
+
+        return result;
+    }
+
+    public async Task<Guid> SaveAsync(MemoryStream text, byte[] iv, string fileName)
+    {
+        var navigationId = Guid.NewGuid();
+        var sql = "INSERT INTO encrypted_files (navigation_id, file_name, content, iv) VALUES (@NavigationId, @FileName, @Content, @IV)";
+        await _db.ExecuteAsync(sql, new
+        {
+            navigationId,
+            fileName,
+            Content = text.ToArray(),
+            IV = iv,
+        });
+
+        return navigationId;
+    }
+}

--- a/backend/src/BlogDoFt.SbusEmulatorViewer.Api/Features/Secrets/Impl/SecretResponse.cs
+++ b/backend/src/BlogDoFt.SbusEmulatorViewer.Api/Features/Secrets/Impl/SecretResponse.cs
@@ -1,0 +1,10 @@
+namespace BlogDoFt.SbusEmulatorViewer.Api.Features.Secrets.Impl;
+
+public record SecretResponse
+{
+    public Guid Id { get; set; }
+
+    public string FileName { get; set; } = string.Empty;
+
+    public string Content { get; set; } = string.Empty;
+}

--- a/backend/src/BlogDoFt.SbusEmulatorViewer.Api/Features/Secrets/Models/SecretSaveModel.cs
+++ b/backend/src/BlogDoFt.SbusEmulatorViewer.Api/Features/Secrets/Models/SecretSaveModel.cs
@@ -1,0 +1,3 @@
+namespace BlogDoFt.SbusEmulatorViewer.Api.Features.Secrets.Models;
+
+public record SecretSaveModel(string FileName, string Text);

--- a/backend/src/BlogDoFt.SbusEmulatorViewer.Api/Features/Secrets/Models/SecretsTable.cs
+++ b/backend/src/BlogDoFt.SbusEmulatorViewer.Api/Features/Secrets/Models/SecretsTable.cs
@@ -1,0 +1,14 @@
+namespace BlogDoFt.SbusEmulatorViewer.Api.Features.Secrets.Models;
+
+public class SecretsTable
+{
+    public int Id { get; set; }
+
+    public Guid NavigationId { get; set; }
+
+    public string? FileName { get; set; }
+
+    public byte[]? Content { get; set; }
+
+    public byte[] IV { get; set; } = [];
+}

--- a/backend/src/BlogDoFt.SbusEmulatorViewer.Api/Features/Secrets/SecretsController.cs
+++ b/backend/src/BlogDoFt.SbusEmulatorViewer.Api/Features/Secrets/SecretsController.cs
@@ -1,0 +1,60 @@
+using BlogDoFt.SbusEmulatorViewer.Api.Features.Secrets.Impl;
+using BlogDoFt.SbusEmulatorViewer.Api.Features.Secrets.Models;
+using Microsoft.AspNetCore.Mvc;
+using System.Net.Mime;
+using System.Text;
+
+namespace BlogDoFt.SbusEmulatorViewer.Api.Features.Secrets;
+
+[ApiController]
+[Route("api/[controller]")]
+[Produces(MediaTypeNames.Application.Json)]
+[Consumes(MediaTypeNames.Application.Json)]
+public class SecretsController : ControllerBase
+{
+    private readonly ISecretCriptographyService _criptographyService;
+    private readonly ISecretRepository _repository;
+
+    public SecretsController(
+        ISecretCriptographyService criptographyService,
+        ISecretRepository repository)
+    {
+        _criptographyService = criptographyService;
+        _repository = repository;
+    }
+
+    [HttpGet(template: "{id}", Name = "QuerySecretByIdAsync")]
+    [ProducesResponseType(type: typeof(SecretResponse), statusCode: StatusCodes.Status201Created)]
+    public async Task<IActionResult> QuerySecretByIdAsync([FromRoute] Guid id)
+    {
+        var table = await _repository.QueryById(id);
+        if (table is null)
+        {
+            return NotFound();
+        }
+
+        var (fileName, decryptedStream) = await _criptographyService.DecryptAsync(table);
+
+        return Ok(new SecretResponse()
+        {
+            Id = id,
+            FileName = fileName,
+            Content = Encoding.UTF8.GetString(decryptedStream.ToArray()),
+        });
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> SaveSecretAsync([FromBody] SecretSaveModel secret)
+    {
+        var (text, iv) = _criptographyService.Encrypt(secret);
+
+        var id = await _repository.SaveAsync(text, iv, secret.FileName);
+
+        await text.DisposeAsync();
+
+        return CreatedAtRoute(
+            routeName: nameof(QuerySecretByIdAsync),
+            routeValues: new { id },
+            value: null);
+    }
+}

--- a/backend/src/BlogDoFt.SbusEmulatorViewer.Api/Features/Secrets/SecretsExtension.cs
+++ b/backend/src/BlogDoFt.SbusEmulatorViewer.Api/Features/Secrets/SecretsExtension.cs
@@ -1,0 +1,11 @@
+using BlogDoFt.SbusEmulatorViewer.Api.Features.Secrets.Impl;
+
+namespace BlogDoFt.SbusEmulatorViewer.Api.Features.Secrets;
+
+public static class SecretsExtension
+{
+    public static IServiceCollection AddSecretsFeature(this IServiceCollection services) =>
+        services
+            .AddScoped<ISecretCriptographyService, SecretCriptographyService>()
+            .AddScoped<ISecretRepository, SecretRepository>();
+}

--- a/backend/src/BlogDoFt.SbusEmulatorViewer.Api/Models/ServiceBusSettings.cs
+++ b/backend/src/BlogDoFt.SbusEmulatorViewer.Api/Models/ServiceBusSettings.cs
@@ -3,5 +3,6 @@ namespace BlogDoFt.SbusEmulatorViewer.Api.Models;
 public class ServiceBusSettings
 {
     public required string ConnectionString { get; init; }
+
     public required string EmulatorConfigFile { get; init; }
 }

--- a/backend/src/BlogDoFt.SbusEmulatorViewer.Api/Program.cs
+++ b/backend/src/BlogDoFt.SbusEmulatorViewer.Api/Program.cs
@@ -1,10 +1,14 @@
 using Azure.Messaging.ServiceBus;
 using Azure.Messaging.ServiceBus.Administration;
+using BlogDoFt.SbusEmulatorViewer.Api.Features.Secrets;
 using BlogDoFt.SbusEmulatorViewer.Api.Models;
 using BlogDoFt.SbusEmulatorViewer.Api.Services;
 using BlogDoFt.SbusEmulatorViewer.Api.Services.Impl;
+using FluentMigrator.Runner;
 using Microsoft.Extensions.Options;
+using Npgsql;
 using Scalar.AspNetCore;
+using System.Data;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -27,6 +31,19 @@ builder.Services
     .Configure<ServiceBusSettings>(builder.Configuration.GetSection("ServiceBus"));
 
 builder.Services
+    .AddSingleton<IDbConnection>(sp =>
+    {
+        var connectionStringBuilder = new NpgsqlConnectionStringBuilder(
+            builder.Configuration.GetConnectionString("Default"));
+
+        return new NpgsqlConnection(connectionStringBuilder.ConnectionString);
+    })
+    .AddFluentMigratorCore()
+        .ConfigureRunner(rb => rb
+            .AddPostgres15_0()
+            .WithGlobalConnectionString(builder.Configuration.GetConnectionString("Default"))
+            .ScanIn(typeof(Program).Assembly).For.Migrations())
+        .AddLogging(lb => lb.AddFluentMigratorConsole())
     .AddSingleton(sp =>
     {
         var settings = sp.GetRequiredService<IOptions<ServiceBusSettings>>().Value;
@@ -38,8 +55,8 @@ builder.Services
         return new ServiceBusAdministrationClient(settings.ConnectionString);
     })
     .AddSingleton<EntitiesParser>()
-    .AddScoped<IServiceBusService, ServiceBusService>();
-
+    .AddScoped<IServiceBusService, ServiceBusService>()
+    .AddSecretsFeature();
 
 builder.Services.AddCors(opts =>
     opts.AddDefaultPolicy(policy =>
@@ -49,6 +66,13 @@ builder.Services.AddCors(opts =>
             .AllowAnyHeader()));
 
 var app = builder.Build();
+
+using (var scope = app.Services.CreateScope())
+{
+    var runner = scope.ServiceProvider.GetRequiredService<IMigrationRunner>();
+
+    runner.MigrateUp();
+}
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())

--- a/backend/src/BlogDoFt.SbusEmulatorViewer.Api/Services/Impl/ServiceBusService.cs
+++ b/backend/src/BlogDoFt.SbusEmulatorViewer.Api/Services/Impl/ServiceBusService.cs
@@ -59,9 +59,9 @@ public class ServiceBusService : IServiceBusService
     }
 }
 
-
 public class MessageDetails
 {
     public object? Body { get; set; }
+
     public object? Details { get; set; }
 }

--- a/backend/src/BlogDoFt.SbusEmulatorViewer.Api/appsettings.Development.json
+++ b/backend/src/BlogDoFt.SbusEmulatorViewer.Api/appsettings.Development.json
@@ -7,6 +7,9 @@
   },
   "ServiceBus": {
     "ConnectionString": "Endpoint=sb://localhost;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;",
-    "EmulatorConfigFile": "/home/ftathiago/src/blogdoft/sbus-emulator-viewer/eng/docker/sbus-emulator/config.json"
+    "EmulatorConfigFile": "<config.json path>"
+  },
+  "ConnectionStrings": {
+    "Default": "Server=<server>;Port=5432;Database=service_bus_emulator;User Id=<user>;Password=<password>"
   }
 }

--- a/backend/src/BlogDoFt.SbusEmulatorViewer.Api/appsettings.json
+++ b/backend/src/BlogDoFt.SbusEmulatorViewer.Api/appsettings.json
@@ -5,9 +5,5 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*",
-  "ServiceBus": {
-    "ConnectionString": "Endpoint=sb://localhost;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;",
-    "EmulatorConfigFile": "/home/ftathiago/src/blogdoft/sbus-emulator-viewer/eng/docker/sbus-emulator/config.json"
-  }
+  "AllowedHosts": "*"
 }

--- a/backend/stylecop.json
+++ b/backend/stylecop.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
+  "settings": {
+    "documentationRules": {
+      "companyName": "BlogDoFT"
+    },
+    "orderingRules": {
+      "usingDirectivesPlacement": "outsideNamespace"
+    }
+  }
+}


### PR DESCRIPTION
This feature will going to help teams to share "public secrets" between then, helping the local environemnt setup.

You can save files in any textual format, like text plain or even json.

Use this to share *local* connection strings, mockable passwords and etc, user secrets and etc.